### PR TITLE
Adding `listing` on chart block

### DIFF
--- a/src/asciidoctor-chart.js
+++ b/src/asciidoctor-chart.js
@@ -63,7 +63,7 @@ const chartBlock = function () {
   self.named('chart')
   self.positionalAttributes(['type', 'width', 'height'])
   self.$content_model('raw')
-  self.onContext('literal')
+  self.onContext(['listing', 'literal'])
 
   self.process(function (parent, reader, attrs) {
     const lines = reader.getLines()

--- a/test/test.js
+++ b/test/test.js
@@ -85,7 +85,7 @@ describe('Conversion', () => {
     })
   })
 
-  const delimeters = ["....", "----"]
+  const delimeters = ['....', '----']
   delimeters.forEach(delimeter => {
     describe(`Block with delimeter ${delimeter}`, () => {
       const chartBlockInput = attrs => `[${['chart'].concat(attrs || []).join(',')}]

--- a/test/test.js
+++ b/test/test.js
@@ -85,15 +85,15 @@ describe('Conversion', () => {
     })
   })
 
-  const delimeters = ['....', '----']
-  delimeters.forEach(delimeter => {
-    describe(`Block with delimeter ${delimeter}`, () => {
+  const delimiters = ['....', '----']
+  delimiters.forEach(delimiter => {
+    describe(`Block with delimiter ${delimiter}`, () => {
       const chartBlockInput = attrs => `[${['chart'].concat(attrs || []).join(',')}]
-${delimeter}
+${delimiter}
 Java,JavaScript,Python
 1.265,1.042,1.024
 1.118,1.004,1.279
-${delimeter}`
+${delimiter}`
       const expectedResult = opts => `<div class="ct-chart" data-chart-height="${opts.height || 400}" data-chart-width="${opts.width || 600}" data-chart-type="${opts.type || 'Line'}" data-chart-colors="#72B3CC,#8EB33B" data-chart-labels="Java,JavaScript,Python" data-chart-series-0="1.265,1.042,1.024" data-chart-series-1="1.118,1.004,1.279"></div>`
       describe('When extension is not registered', () => {
         it('should not convert a block chart', () => {
@@ -114,8 +114,8 @@ ${delimeter}`
         })
         it('should not convert a chart if the series are empty', () => {
           const input = `[chart]
-${delimeter}
-${delimeter}`
+${delimiter}
+${delimiter}`
           const registry = asciidoctor.Extensions.create()
           asciidoctorChart.register(registry)
           const html = asciidoctor.convert(input, { extension_registry: registry })

--- a/test/test.js
+++ b/test/test.js
@@ -84,68 +84,72 @@ describe('Conversion', () => {
       expect(html).to.contain(expectedResult({ type: 'Bar', width: 500, height: 700 }))
     })
   })
-  describe('Block', () => {
-    const chartBlockInput = attrs => `[${['chart'].concat(attrs || []).join(',')}]
-....
+
+  const delimeters = ["....", "----"]
+  delimeters.forEach(delimeter => {
+    describe(`Block with delimeter ${delimeter}`, () => {
+      const chartBlockInput = attrs => `[${['chart'].concat(attrs || []).join(',')}]
+${delimeter}
 Java,JavaScript,Python
 1.265,1.042,1.024
 1.118,1.004,1.279
-....`
-    const expectedResult = opts => `<div class="ct-chart" data-chart-height="${opts.height || 400}" data-chart-width="${opts.width || 600}" data-chart-type="${opts.type || 'Line'}" data-chart-colors="#72B3CC,#8EB33B" data-chart-labels="Java,JavaScript,Python" data-chart-series-0="1.265,1.042,1.024" data-chart-series-1="1.118,1.004,1.279"></div>`
-    describe('When extension is not registered', () => {
-      it('should not convert a block chart', () => {
-        const input = chartBlockInput()
-        const html = asciidoctor.convert(input)
-        expect(html).to.contain(`<pre>Java,JavaScript,Python
+${delimeter}`
+      const expectedResult = opts => `<div class="ct-chart" data-chart-height="${opts.height || 400}" data-chart-width="${opts.width || 600}" data-chart-type="${opts.type || 'Line'}" data-chart-colors="#72B3CC,#8EB33B" data-chart-labels="Java,JavaScript,Python" data-chart-series-0="1.265,1.042,1.024" data-chart-series-1="1.118,1.004,1.279"></div>`
+      describe('When extension is not registered', () => {
+        it('should not convert a block chart', () => {
+          const input = chartBlockInput()
+          const html = asciidoctor.convert(input)
+          expect(html).to.contain(`<pre>Java,JavaScript,Python
 1.265,1.042,1.024
 1.118,1.004,1.279</pre>`)
+        })
       })
-    })
-    describe('When extension is registered', () => {
-      it('should convert a chart', () => {
-        const input = chartBlockInput()
+      describe('When extension is registered', () => {
+        it('should convert a chart', () => {
+          const input = chartBlockInput()
+          const registry = asciidoctor.Extensions.create()
+          asciidoctorChart.register(registry)
+          const html = asciidoctor.convert(input, { extension_registry: registry })
+          expect(html).to.contain(expectedResult({}))
+        })
+        it('should not convert a chart if the series are empty', () => {
+          const input = `[chart]
+${delimeter}
+${delimeter}`
+          const registry = asciidoctor.Extensions.create()
+          asciidoctorChart.register(registry)
+          const html = asciidoctor.convert(input, { extension_registry: registry })
+          expect(html).to.contain('[chart is empty]')
+        })
+      })
+      it('should convert a chart into a bar chart', () => {
+        const input = chartBlockInput(['bar'])
         const registry = asciidoctor.Extensions.create()
         asciidoctorChart.register(registry)
         const html = asciidoctor.convert(input, { extension_registry: registry })
-        expect(html).to.contain(expectedResult({}))
+        expect(html).to.contain(expectedResult({ type: 'Bar' }))
       })
-      it('should not convert a chart if the series are empty', () => {
-        const input = `[chart]
-....
-....`
+      it('should convert a chart into a line chart with a width of 500px', () => {
+        const input = chartBlockInput(['width=500'])
         const registry = asciidoctor.Extensions.create()
         asciidoctorChart.register(registry)
         const html = asciidoctor.convert(input, { extension_registry: registry })
-        expect(html).to.contain('[chart is empty]')
+        expect(html).to.contain(expectedResult({ width: '500' }))
       })
-    })
-    it('should convert a chart into a bar chart', () => {
-      const input = chartBlockInput(['bar'])
-      const registry = asciidoctor.Extensions.create()
-      asciidoctorChart.register(registry)
-      const html = asciidoctor.convert(input, { extension_registry: registry })
-      expect(html).to.contain(expectedResult({ type: 'Bar' }))
-    })
-    it('should convert a chart into a line chart with a width of 500px', () => {
-      const input = chartBlockInput(['width=500'])
-      const registry = asciidoctor.Extensions.create()
-      asciidoctorChart.register(registry)
-      const html = asciidoctor.convert(input, { extension_registry: registry })
-      expect(html).to.contain(expectedResult({ width: '500' }))
-    })
-    it('should convert a chart into a line chart with an height of 700px', () => {
-      const input = chartBlockInput(['height=700'])
-      const registry = asciidoctor.Extensions.create()
-      asciidoctorChart.register(registry)
-      const html = asciidoctor.convert(input, { extension_registry: registry })
-      expect(html).to.contain(expectedResult({ height: '700' }))
-    })
-    it('should convert a chart into a bar chart with a width of 500px and a height of 700px', () => {
-      const input = chartBlockInput(['bar', '500', '700'])
-      const registry = asciidoctor.Extensions.create()
-      asciidoctorChart.register(registry)
-      const html = asciidoctor.convert(input, { extension_registry: registry })
-      expect(html).to.contain(expectedResult({ type: 'Bar', width: 500, height: 700 }))
+      it('should convert a chart into a line chart with an height of 700px', () => {
+        const input = chartBlockInput(['height=700'])
+        const registry = asciidoctor.Extensions.create()
+        asciidoctorChart.register(registry)
+        const html = asciidoctor.convert(input, { extension_registry: registry })
+        expect(html).to.contain(expectedResult({ height: '700' }))
+      })
+      it('should convert a chart into a bar chart with a width of 500px and a height of 700px', () => {
+        const input = chartBlockInput(['bar', '500', '700'])
+        const registry = asciidoctor.Extensions.create()
+        asciidoctorChart.register(registry)
+        const html = asciidoctor.convert(input, { extension_registry: registry })
+        expect(html).to.contain(expectedResult({ type: 'Bar', width: 500, height: 700 }))
+      })
     })
   })
 })


### PR DESCRIPTION
With this modification, chart can be used with those both example :

```
[chart]
----
January,February,March
28,48,40
65,59,80
----
```

OR

```
[chart]
....
January,February,March
28,48,40
65,59,80
....
```